### PR TITLE
Fix escapeString to handle parameters that contain spaces.

### DIFF
--- a/CasparServerConnector.php
+++ b/CasparServerConnector.php
@@ -56,7 +56,10 @@ class CasparServerConnector
 	}
 	
 	public static function escapeString($string) {
-		return str_replace('"', '\"', str_replace("\n", '\n', str_replace('\\', '\\\\', $string)));
+		$escaped = str_replace('"', '\"', str_replace("\n", '\n', str_replace('\\', '\\\\', $string)));
+		if (strpos($escaped, " ") !== false) {
+			$escaped = '"' . $escaped . '"';
+		return $escaped;
 	}
 	
 	public function closeSocket() {


### PR DESCRIPTION
escapeString will escape a single parameter containing spaces into a string CasparCG will interpret as being multiple parameters. If a parameter contains a space, it should be surrounded with quote marks.
